### PR TITLE
Add `launch` command, fix icon installation (incuding both 32x32 & 16x16), plus `Makefile` improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := /usr/bin/env bash
+SHELL ?= /bin/sh
 PYTHON_BIN ?= python
 
 .ONESHELL:

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,26 @@
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
+PYTHON_BIN ?= python
 
 .ONESHELL:
 .PHONY: build
 
 build:
-	python -m venv .venv
-	source .venv/bin/activate
-	python -m pip install -r requirements.txt
-	python -m pip install pyinstaller
+	$(PYTHON_BIN) -m pip install -r requirements.txt
+	$(PYTHON_BIN) -m pip install pyinstaller
 	pyinstaller --onefile --clean --strip ffssb.py
 
+build-venv:
+	$(PYTHON_BIN) -m venv .venv
+	source .venv/bin/activate
+	make build
+
 clean:
-	rm -rf .venv/
 	rm -rf build/
+	rm -rf dist/
 	rm -f ffssb.spec
+
+clean-venv: clean
+	rm -rf .venv/
+
+install:
+	install -m 755 dist/ffssb /usr/local/bin

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The easiest way to get started:
 ``` sh
 git clone https://github.com/sebastianappler/ffssb
 make
-mv ./dist/ffssb /usr/local/bin
+make install
 ```
 
 It's also possible to run the python script directly:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ ffssb create hn https://news.ycombinator.com/ --display-name "Hacker News"
 ```
 
 Then search for "Hacker News" in your applications (press Super-key, start
-typing) and start it.
+typing) and start it. Alternatively, launch the ssb from the command line
+by typing:
+``` sh
+ffssb launch hn
+```
 
 To show more commands:
 ``` sh

--- a/ffssb.py
+++ b/ffssb.py
@@ -307,6 +307,16 @@ def list(args):
         name, url = v
         print ("{:<20} {:<20}".format(name, url))
 
+def launch(args):
+    desktop_path = get_desktop_entry_path(args.name)
+    if os.path.exists(desktop_path):
+        with open(desktop_path, 'r') as fp:
+            file_text = fp.read()
+            exec_cmd = re.findall(r'^(?:Exec=)(.+)$', file_text, re.MULTILINE)[0]
+            if len(exec_cmd) == 0:
+                return
+            os.system(exec_cmd)
+
 def remove(args):
     ffssb_name = cfg['ffssb_prefix'] + args.name
     profile_path = cfg['ffsettings_dir'] + ffssb_name
@@ -337,6 +347,11 @@ def main():
     # list
     parser_list = subparsers.add_parser('list', help = 'list all site specific browsers created by this tool.')
     parser_list.set_defaults(func=list)
+
+    # launch
+    parser_launch = subparsers.add_parser('launch', help = 'launch site specific browser application.')
+    parser_launch.add_argument('name', help='name of the application')
+    parser_launch.set_defaults(func=launch)
 
     # remove
     parser_remove = subparsers.add_parser('remove', help = 'remove site specific browser application.')

--- a/ffssb.py
+++ b/ffssb.py
@@ -160,11 +160,19 @@ def add_desktop_entry_icon(name, url):
         ico_file = requests.get(ico_url)
         open(icon_path, 'wb').write(ico_file.content)
 
-    img = Image.open(icon_path)
-    img_path = cfg['os_icons_dir'] + '32x32' + os.path.sep + 'apps' + os.path.sep + name + '.png'
-    img.save(img_path, format = 'PNG', sizes=[(32,32)])
+    icon_sizes = ['16', '32']
+    img_paths = {}
+    for size in icon_sizes:
+        app_icons_path = cfg['os_icons_dir'] + '{0}x{0}'.format(size) + os.path.sep + 'apps'
+        if not os.path.exists(app_icons_path):
+            os.makedirs(app_icons_path)
 
-    return img_path
+        img_paths[size] = app_icons_path + os.path.sep + name + '.png'
+        if not os.path.exists(img_paths[size]):
+            img = Image.open(icon_path)
+            img.save(img_paths[size], format = 'PNG', sizes=[(size, size)])
+
+    return img_paths['32']
 
 def add_user_chrome(profile_path):
     chrome_css = '''@namespace url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");


### PR DESCRIPTION
Thanks for this project, @sebastianappler! I mostly use Firefox at this point and wanted to test out creating site-specific browsers (SSBs.) Yours is the most complete solution I've found so far.

This PR implements a number of improvements I needed to make it work in my environment ([OpenBSD](https://www.openbsd.org/) amd64/7.4-stable running the [MLVWM](https://github.com/morgant/mlvwm) window manager; especially the lack of a full desktop environment [DE] with support for `.desktop` files):

1. A new `ffssb launch` command which will execute the command from the SSB's `.desktop` file
2. Fixes installation of the SSB icon when the target directory structure doesn't exist
3. Installs both 32x32 (current) and 16x16 (new) variants of the SSB icon
4. Updates the `Makefile`:
    * Allow overriding the `python` binary name/path (e.g. `python3` under OpenBSD)
    * Building with `venv` is optional (`make build-env` or `make build`; OpenBSD doesn't support `venv`)
    * New `make install` target so that `make && make install` is really all that's required to build & install

I haven't tested the `Makefile` changes under a non-BSD OS (e.g. Linux or macOS) yet, so worth confirming I've not introduced any issues there. Happy to cherry-pick the individual commits and split into separate PRs if you'd prefer.