### PR TITLE
`Makefile` fixes for `venv`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 SHELL ?= /bin/sh
 PYTHON_BIN ?= python
 
-.ONESHELL:
 .PHONY: build
 
 build:

--- a/Makefile
+++ b/Makefile
@@ -5,22 +5,16 @@ PYTHON_BIN ?= python
 .PHONY: build
 
 build:
-	$(PYTHON_BIN) -m pip install -r requirements.txt
-	$(PYTHON_BIN) -m pip install pyinstaller
-	pyinstaller --onefile --clean --strip ffssb.py
-
-build-venv:
 	$(PYTHON_BIN) -m venv .venv
-	source .venv/bin/activate
-	make build
+	. .venv/bin/activate && pip install -r requirements.txt
+	. .venv/bin/activate && pip install pyinstaller
+	. .venv/bin/activate && pyinstaller --onefile --clean --strip ffssb.py
 
 clean:
+	rm -rf .venv/
 	rm -rf build/
 	rm -rf dist/
 	rm -f ffssb.spec
-
-clean-venv: clean
-	rm -rf .venv/
 
 install:
 	install -m 755 dist/ffssb /usr/local/bin

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,26 @@
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
+PYTHON_BIN ?= python
 
 .ONESHELL:
 .PHONY: build
 
 build:
-	python -m venv .venv
-	source .venv/bin/activate
-	python -m pip install -r requirements.txt
-	python -m pip install pyinstaller
+	$(PYTHON_BIN) -m pip install -r requirements.txt
+	$(PYTHON_BIN) -m pip install pyinstaller
 	pyinstaller --onefile --clean --strip ffssb.py
 
+build-venv:
+	$(PYTHON_BIN) -m venv .venv
+	source .venv/bin/activate
+	make build
+
 clean:
-	rm -rf .venv/
 	rm -rf build/
+	rm -rf dist/
 	rm -f ffssb.spec
+
+clean-venv: clean
+	rm -rf .venv/
+
+install:
+	install -m 755 dist/ffssb /usr/local/bin

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The easiest way to get started:
 ``` sh
 git clone https://github.com/sebastianappler/ffssb
 make
-mv ./dist/ffssb /usr/local/bin
+make install
 ```
 
 It's also possible to run the python script directly:

--- a/README.md
+++ b/README.md
@@ -19,14 +19,32 @@ Supports linux, tested on fedora with gnome.
 
 ### Install
 
-The easiest way to get started:
+The easiest way to get started, if your environment uses GNU make and bash/zsh:
 ``` sh
 git clone https://github.com/sebastianappler/ffssb
-make
-make install
+make && make install
 ```
 
-It's also possible to run the python script directly:
+If you're using a shell other than bash/zsh:
+``` sh
+git clone https://github.com/sebastianappler/ffssb
+bash -c 'make && make install'
+```
+
+You can also specify an alternate Python binary:
+``` sh
+git clone https://github.com/sebastianappler/ffssb
+PYTHON_BIN="$(which python3)" make && make install
+```
+
+You can combine the above, as well. For example, on [OpenBSD](https://www.openbsd.org/), one would install as follows:
+``` sh
+pkg_add git python3 gmake
+git clone https://github.com/sebastianappler/ffssb
+PYTHON_BIN="$(which python3)" bash -c 'gmake && gmake install'
+```
+
+Finally, it's also possible to run the python script directly:
 ``` sh
 pip install -r requirements.txt
 python ffssb.py <cmd>

--- a/README.md
+++ b/README.md
@@ -19,29 +19,16 @@ Supports linux, tested on fedora with gnome.
 
 ### Install
 
-The easiest way to get started, if your environment uses GNU make and bash/zsh:
+The easiest way to get started:
 ``` sh
 git clone https://github.com/sebastianappler/ffssb
 make && make install
-```
-
-If you're using a shell other than bash/zsh:
-``` sh
-git clone https://github.com/sebastianappler/ffssb
-bash -c 'make && make install'
 ```
 
 You can also specify an alternate Python binary:
 ``` sh
 git clone https://github.com/sebastianappler/ffssb
 PYTHON_BIN="$(which python3)" make && make install
-```
-
-You can combine the above, as well. For example, on [OpenBSD](https://www.openbsd.org/), one would install as follows:
-``` sh
-pkg_add git python3 gmake
-git clone https://github.com/sebastianappler/ffssb
-PYTHON_BIN="$(which python3)" bash -c 'gmake && gmake install'
 ```
 
 Finally, it's also possible to run the python script directly:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ ffssb create hn https://news.ycombinator.com/ --display-name "Hacker News"
 ```
 
 Then search for "Hacker News" in your applications (press Super-key, start
-typing) and start it.
+typing) and start it. Alternatively, launch the ssb from the command line
+by typing:
+``` sh
+ffssb launch hn
+```
 
 To show more commands:
 ``` sh

--- a/ffssb.py
+++ b/ffssb.py
@@ -307,6 +307,16 @@ def list(args):
         name, url = v
         print ("{:<20} {:<20}".format(name, url))
 
+def launch(args):
+    desktop_path = get_desktop_entry_path(args.name)
+    if os.path.exists(desktop_path):
+        with open(desktop_path, 'r') as fp:
+            file_text = fp.read()
+            exec_cmd = re.findall(r'^(?:Exec=)(.+)$', file_text, re.MULTILINE)[0]
+            if len(exec_cmd) == 0:
+                return
+            os.system(exec_cmd)
+
 def remove(args):
     ffssb_name = cfg['ffssb_prefix'] + args.name
     profile_path = cfg['ffsettings_dir'] + ffssb_name
@@ -337,6 +347,11 @@ def main():
     # list
     parser_list = subparsers.add_parser('list', help = 'list all site specific browsers created by this tool.')
     parser_list.set_defaults(func=list)
+
+    # launch
+    parser_launch = subparsers.add_parser('launch', help = 'launch site specific browser application.')
+    parser_launch.add_argument('name', help='name of the application')
+    parser_launch.set_defaults(func=launch)
 
     # remove
     parser_remove = subparsers.add_parser('remove', help = 'remove site specific browser application.')

--- a/ffssb.py
+++ b/ffssb.py
@@ -160,11 +160,19 @@ def add_desktop_entry_icon(name, url):
         ico_file = requests.get(ico_url)
         open(icon_path, 'wb').write(ico_file.content)
 
-    img = Image.open(icon_path)
-    img_path = cfg['os_icons_dir'] + '32x32' + os.path.sep + 'apps' + os.path.sep + name + '.png'
-    img.save(img_path, format = 'PNG', sizes=[(32,32)])
+    icon_sizes = ['16', '32']
+    img_paths = {}
+    for size in icon_sizes:
+        app_icons_path = cfg['os_icons_dir'] + '{0}x{0}'.format(size) + os.path.sep + 'apps'
+        if not os.path.exists(app_icons_path):
+            os.makedirs(app_icons_path)
 
-    return img_path
+        img_paths[size] = app_icons_path + os.path.sep + name + '.png'
+        if not os.path.exists(img_paths[size]):
+            img = Image.open(icon_path)
+            img.save(img_paths[size], format = 'PNG', sizes=[(size, size)])
+
+    return img_paths['32']
 
 def add_user_chrome(profile_path):
     chrome_css = '''@namespace url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");


### PR DESCRIPTION
Thanks again for merging my prior PR #1! I re-tested under [OpenBSD](https://www.openbsd.org/) amd64/7.4-stable and ran into complaints from `pip` re:Python being managed by OpenBSD's `pkg_add` and that `venv` _should_ actually work now.

While troubleshooting, I found that the `source .venv/bin/activate` line fails and should actually use `.` instead. Additionally, for the virtualenv to be correctly activated, it should executed on the same line as the `pip`/`pyinstaller` use so that they're sharing a shell instance. With these corrections, I can actually use virtualenv on OpenBSD and revert some of the `Makefile` improvements from PR #1.

This PR includes the following fixes:

* `Makefile`:
    * Reverts split of `build` & `clean` targets from PR #1 and always uses `venv` (even on OpenBSD)
    * Correctly activates & uses the virtualenv
    * Updates the `clean` target to also delete the virtualenv
* Updates `README.md`:
    * Note the requirements of `bash`/`zsh` shell (for `.venv/bin/activate`) & GNU `make`
    * Adds examples for installing using a non-`bash`/`zsh` shell and/or non-GNU `make` (incl. OpenBSD)

This _should_ get us back to a simpler/unified `Makefile` and ensure that `venv` is utilized across all platforms. I haven't tested under non-BSD (e.g. Linux distros), so please test and let me know if you run into any issues.